### PR TITLE
 [버그] 해로쿠 배포 후 해시태그 등록 오류 수정

### DIFF
--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -9,6 +9,8 @@ insert into user_account (user_id, user_password, nickname, email, memo, created
 values ('uno2', '{noop}asdf1234', 'Uno2', 'uno2@mail.com', 'I am Uno2.', now(), 'uno2', now(), 'uno2')
 ;
 
+ALTER TABLE Hashtag CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
 -- 123 게시글
 insert into article (user_id, title, content, created_by, modified_by, created_at, modified_at)
 values ('uno2', 'Quisque ut erat.', 'Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.


### PR DESCRIPTION
1. 에러 직후 화면에서 에러의 원인을 분석하려면 무엇을 봐야 하는가?
에러의 원인을 분석하려면 가장 먼저 봐야할 것은 해당 서버의 로그입니다.
에러는 현재 로컬에서 재현이 안되고, 헤로쿠에서만 발생하고 있습니다.
그렇다면 봐야할 것은 로컬의 로그와, 헤로쿠의 로그 둘 다입니다. 하지만 특히 헤로쿠에서 발생하는 에러 로그를 유심히 봐야겠죠.
로컬에서는 에러가 발생하지 않으므로, 로컬의 로그는 대체로 info 레벨의 정상적인 로그일 것입니다.
때문에 로컬 로그는 일종의 참고용, 헤로쿠와 비교해보기 위한 목적으로 분석합니다.
가장 중요한 것은 역시 에러를 알려주는 헤로쿠의 로그이겠지요.

3. 에러 내용을 분석했을 때 문제의 원인은 무엇인가?
에러를 발생 시킨 후 해당 로그를 찾았습니다.
핵심은 java.sql.SQLIntegrityConstraintViolationException:Duplicate entry 'Test' for key 'hashtag....' 부분 이였습니다.
'Test' 값은 'hashtag' 테이블의 ....라는 unique키에 이미 존재한다는 것을 의미합니다.
해당 내용은 SQL데이터베이스에서 이미 존재하는 값이 삽입되려고 할 때 발생합니다.
'Test' 라는 단어를 해시태그로 넣으려 했기 때문에 생긴 오류가 아니었습니다.
(제가 테스트시 'Test' 해시태그를 등록하기 전에 이미 'test '라는 해시태그를 사용했었습니다.)

4. 왜 헤로쿠에서 해당 문제가 발생하였는가?
헤로쿠에서 배포시 MYSQL을 사용해서 그렇습니다.
MYSQL은 기본적으로 대소문자를 구분하지 않는다고 합니다.
(헤로쿠에서 사용하는 MYSQL에서는 'Test'와 'test'를 동일한 값으로 간주한 것 같습니다.)

This close #105 

5. 왜 로컬에서는 재현이 안되었는가?
로컬에서는 PostgreSQL을 사용해서 그렇습니다.
PostgreSQL은 기본적으로 대소문자를 구분한다고 합니다.

6. 적절한 해결법은?
제가 생각한 해결법은 테이블 설정에서 대소문자를 구분하여 중복을 허용해 주는것 입니다.
data.sql에 ALTER TABLE Hahshtag CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;문을 추가해 줍니다.

요약 : MySQL의 대소문자 구분안함 설정이 문제였습니다. 해시태그 테이블의 대소문자 구분 중복 허용 설정으로 해결할 수 있었습니다. (data.sql에 ALTER HashtagYourTableName CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin; 추가)