### PR TITLE
[버그] 해로쿠 배포 후 해시태그 등록 오류 수정

### DIFF
--- a/src/main/java/com/example/projectboard/domain/Hashtag.java
+++ b/src/main/java/com/example/projectboard/domain/Hashtag.java
@@ -27,7 +27,7 @@ public class Hashtag extends AuditingFields {
     @ManyToMany(mappedBy = "hashtags")
     private Set<Article> articles = new LinkedHashSet<>();
 
-    @Setter @Column(nullable = false) private String hashtagName; // 해시태그 이름
+    @Setter @Column(nullable = false,columnDefinition="varchar(255) COLLATE utf8mb4_bin") private String hashtagName; // 해시태그 이름
 
 
     protected Hashtag() {}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -9,8 +9,6 @@ insert into user_account (user_id, user_password, nickname, email, memo, created
 values ('uno2', '{noop}asdf1234', 'Uno2', 'uno2@mail.com', 'I am Uno2.', now(), 'uno2', now(), 'uno2')
 ;
 
-ALTER TABLE Hashtag CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-
 -- 123 게시글
 insert into article (user_id, title, content, created_by, modified_by, created_at, modified_at)
 values ('uno2', 'Quisque ut erat.', 'Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.


### PR DESCRIPTION
1. 대소문자 구분을 하게 만들어서 중복을 허용하는건지, 안하는건지?
해시태그를 등록하는 로직에서는 test와 Test를 따로 구분하는데,mysql에서 test와 Test둘다 test로 인식을 하여 생긴 문제였습니다. 그래서 저는
mysql에서 'test' 와 'Test'를 구분하게 하여 test와 Test둘다 해시태그 테이블에 저장이 되게 했습니다.
test와 Test를 구분하는것은 중복을 허용하지 않는 것이라고 생각하여야 맞는 것 같습니다.

2. 해당 ddl 문장이 어떻게 mysql 테이블에서 대소문자 구분을 가능하게 하는 건지?
해당 DDL문장은 테이블의 Collation을 변경하여 MySQL에서 대소문자를 구분하도록 만듭니다. 'utf8mb4_bin'은 바이너리 Collation으로, 대소문자를 구분하여 문자열을 비교하여 Test와 test를 다른값으로 인식합니다.
utf8mb4은 'utf8mb4_bin'을 사용하기 위해 Hashtag테이블의 charset을 utf8mb4로 한것입니다.

3. 헤로쿠 테이블을 직접 조작하려는 것 같은데 이렇게 해도 헤로쿠를 이용하여 서비스하는데 다른 부작용은 없는지?
현재 제가 해로쿠에 배포한 서비스는 'sql.init.mode: always' 의 설정을 가지고 있기 때문에 테이블을 조작하는 것이 상관없을 것으로 생각했었습니다.
데이터가 계속 초기화되는 과정중에 추가한 DDL또한 문제 없이 실행된다면 상관없다 라고 생각했었습니다.
서비스를 배포할때 sql.init.mode: always설정을 사용한것이 잘못일 것입니다.
하지만 현실적으로 저밖에 안쓸것이라고 생각 해서 편한 배포 후 테스트를 위해 설정을 그대로 두었습니다.

4. data.sql에 ddl 을 사용하는 것이 최선의 방법인지?
data.sql의 ddl을 사용하는것은 사실 제 입장에서 제일 간편하게 해결할 수 있는 방법 이여서 선택할 수 있었습니다.
ddl을 사용하는데 문제도 없을 것이고, MySQL을 계속 사용할 것이기 때문에 복사 붙여넣기만 하면 끝입니다.
저 처럼 특수한 경우가 아니라면(sql.init.mode: always 가 아니라면) Hashtag 클래스를 찾아서 hashtagName의 @Column의 속성에 columnDefinition="varchar(255) COLLATE utf8mb4_bin"을 추가해주는 방식이 나은 것 같습니다.

5. 이 방법의 장단점은 무엇인지? 단점을 고려했을 때 더 고민할 필요없이 이대로 만족하면 되는 최선의 해법인지?
장점 : data.sql에 복사 붙여넣기만 하면 끝이라 간편하다.
단점 : Collation을 지원하는 방법이 데이터베이스 마다 다르기 때문에 데이터베이스를 바꾸면 오류가 생길 가능성이 있다.
데이터베이스를 초기화하지 않는 보통의 서비스라면 기존의 데이터와의 호환성을 고려하여야 한다.

6. 그렇지 않다면 다른 더 나은 해결 방법은 무엇이 있을지?
Hashtag 엔티티의 column속성에 columnDefinition속성을 추가하는게 여러 데이터베이스와의 호환성을 봐서라도 좋은 것 같습니다.

This close #105 